### PR TITLE
forward-client-virtual-host

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A list of small tweaks I made:
     - Mapping between online / offline uuid will be updated on player connected
     - The sqlite database file can be shared between multiple velocity instances
   - UUID rewrite can be disabled by setting `enabled = false`
+- Added advanced proxy setting to forward client virtual host
+  - setting to overwrite handshake packet host and port between virtual host or backend server
 
 # Velocity
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -460,6 +460,11 @@ public class VelocityConfiguration implements ProxyConfig {
     return forceKeyAuthentication;
   }
 
+  // [kahzerx's fork] forward client virtual host
+  public boolean isForwardClientVirtualHost() {
+    return this.advanced.forwardClientVirtualHost;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -773,6 +778,8 @@ public class VelocityConfiguration implements ProxyConfig {
     private boolean logPlayerConnections = true;
     @Expose
     private boolean acceptTransfers = false;
+    @Expose
+    private boolean forwardClientVirtualHost = true;  // [kahzerx's fork] forward client virtual host
 
     private Advanced() {
     }
@@ -798,6 +805,7 @@ public class VelocityConfiguration implements ProxyConfig {
         this.logCommandExecutions = config.getOrElse("log-command-executions", false);
         this.logPlayerConnections = config.getOrElse("log-player-connections", true);
         this.acceptTransfers = config.getOrElse("accepts-transfers", false);
+        this.forwardClientVirtualHost = config.getOrElse("forward-client-virtual-host", true);
       }
     }
 
@@ -861,6 +869,10 @@ public class VelocityConfiguration implements ProxyConfig {
       return this.acceptTransfers;
     }
 
+    public boolean isForwardClientVirtualHost() {
+      return forwardClientVirtualHost;
+    }
+
     @Override
     public String toString() {
       return "Advanced{"
@@ -878,6 +890,7 @@ public class VelocityConfiguration implements ProxyConfig {
           + ", logCommandExecutions=" + logCommandExecutions
           + ", logPlayerConnections=" + logPlayerConnections
           + ", acceptTransfers=" + acceptTransfers
+          + ", forwardClientVirtualHost=" + forwardClientVirtualHost
           + '}';
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -170,7 +170,6 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
 
   private void startHandshake() {
     final MinecraftConnection mc = ensureConnected();
-    PlayerInfoForwarding forwardingMode = server.getConfiguration().getPlayerInfoForwardingMode();
 
     // Initiate the handshake.
     ProtocolVersion protocolVersion = proxyPlayer.getConnection().getProtocolVersion();
@@ -183,6 +182,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
       playerVhost = registeredServer.getServerInfo().getAddress().getHostString();
     }
 
+    PlayerInfoForwarding forwardingMode = server.getConfiguration().getPlayerInfoForwardingMode();
     HandshakePacket handshake = new HandshakePacket();
     handshake.setIntent(HandshakeIntent.LOGIN);
     handshake.setProtocolVersion(protocolVersion);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -140,18 +140,28 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   }
 
   private String createLegacyForwardingAddress() {
+    String host;
+    if (server.getConfiguration().isForwardClientVirtualHost()) {
+      host = proxyPlayer.getVirtualHost().orElseGet(() -> registeredServer.getServerInfo().getAddress()).getHostString();
+    } else {
+      host = registeredServer.getServerInfo().getAddress().getHostString();
+    }
     return PlayerDataForwarding.createLegacyForwardingAddress(
-      proxyPlayer.getVirtualHost().orElseGet(() ->
-        registeredServer.getServerInfo().getAddress()).getHostString(),
+      host,
       getPlayerRemoteAddressAsString(),
       proxyPlayer.getGameProfile()
     );
   }
 
   private String createBungeeGuardForwardingAddress(byte[] forwardingSecret) {
+    String host;
+    if (server.getConfiguration().isForwardClientVirtualHost()) {
+      host = proxyPlayer.getVirtualHost().orElseGet(() -> registeredServer.getServerInfo().getAddress()).getHostString();
+    } else {
+      host = registeredServer.getServerInfo().getAddress().getHostString();
+    }
     return PlayerDataForwarding.createBungeeGuardForwardingAddress(
-      proxyPlayer.getVirtualHost().orElseGet(() ->
-        registeredServer.getServerInfo().getAddress()).getHostString(),
+      host,
       getPlayerRemoteAddressAsString(),
       proxyPlayer.getGameProfile(),
       forwardingSecret
@@ -164,9 +174,14 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
 
     // Initiate the handshake.
     ProtocolVersion protocolVersion = proxyPlayer.getConnection().getProtocolVersion();
-    String playerVhost = proxyPlayer.getVirtualHost()
-                .orElseGet(() -> registeredServer.getServerInfo().getAddress())
-                .getHostString();
+    String playerVhost;
+    if (server.getConfiguration().isForwardClientVirtualHost()) {
+      playerVhost = proxyPlayer.getVirtualHost()
+              .orElseGet(() -> registeredServer.getServerInfo().getAddress())
+              .getHostString();
+    } else {
+      playerVhost = registeredServer.getServerInfo().getAddress().getHostString();
+    }
 
     HandshakePacket handshake = new HandshakePacket();
     handshake.setIntent(HandshakeIntent.LOGIN);
@@ -185,9 +200,13 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
       handshake.setServerAddress(playerVhost);
     }
 
-    handshake.setPort(proxyPlayer.getVirtualHost()
-            .orElseGet(() -> registeredServer.getServerInfo().getAddress())
-            .getPort());
+    if (server.getConfiguration().isForwardClientVirtualHost()) {
+      handshake.setPort(proxyPlayer.getVirtualHost()
+              .orElseGet(() -> registeredServer.getServerInfo().getAddress())
+              .getPort());
+    } else {
+      handshake.setPort(registeredServer.getServerInfo().getAddress().getPort());
+    }
     mc.delayedWrite(handshake);
 
     mc.setProtocolVersion(protocolVersion);

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -145,6 +145,11 @@ log-player-connections = true
 # Transfer packet (Minecraft 1.20.5) to be received.
 accepts-transfers = false
 
+# [kahzerx's fork]
+# If set to false, modifies the virtual host to match the server address in the handshake.
+# Useful when backends require players to connect with a specific dns.
+forward-client-virtual-host = true
+
 # [fallen's fork] mojang auth proxy
 # See readme for more information
 [auth-proxy]


### PR DESCRIPTION
Added advanced proxy setting to forward client virtual host: `forward-client-virtual-host`

If set to false, modifies the virtual host to match the server address in the handshake
Useful when backends require players to connect with a specific dns

default value `true`, keeps current logic to extract address and port